### PR TITLE
Rename Claude Code command for frontend-specific features

### DIFF
--- a/.claude/commands/implement-frontend-feature.md
+++ b/.claude/commands/implement-frontend-feature.md
@@ -1,7 +1,7 @@
-You will be implementing a new feature in this codebase
+You will be implementing a new frontend feature in this codebase
 
 $ARGUMENTS
 
-IMPORTANT: Only do this for front-end features.
+IMPORTANT: Only do this for frontend features.
 Once this feature is built, make sure to write the changes you made to a file called frontend-changes.md
 Do not ask for permissions to modify this file, assume you can always do it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Icon-based theme toggle button following existing design patterns
 
 ### Changed
+- Renamed Claude Code command from `implement-feature.md` to `implement-frontend-feature.md` for clarity
 - Updated commit-all command to clarify using Claude Code command syntax (/log-changes)
 - Refactored `generate_response` method in AIGenerator to support sequential tool calling while maintaining backward compatibility
 - Updated system prompt to include examples and guidance for multi-step reasoning patterns


### PR DESCRIPTION
- Renamed implement-feature.md to implement-frontend-feature.md
- Updated command to be more specific about its frontend-only purpose
- Ensures proper separation of frontend and backend feature implementation

🤖 Generated with [Claude Code](https://claude.ai/code)